### PR TITLE
Update day 26 ( Frequent array)

### DIFF
--- a/day 26 ( Frequent array)
+++ b/day 26 ( Frequent array)
@@ -1,6 +1,4 @@
-#include<iostream>
-#include<vector>
-#include<algorithm>
+#include <bits/stdc++.h>
 using namespace std;
 int main(){
     int n;


### PR DESCRIPTION
#include <bits/stdc++.h> is a non-standard, convenient header file available in some C++ compilers, particularly with GCC. It imports all standard C++ libraries in one go, such as:

<iostream>
<vector>
<string>
<algorithm>
<cmath>
and many more...